### PR TITLE
Use sys.executable for spawning Python subprocesses

### DIFF
--- a/book/examples/RunExamples.py
+++ b/book/examples/RunExamples.py
@@ -3,7 +3,7 @@
 # . Some way of verifying the results of the examples is necessary (to do away with DifferenceLogs).
 # . Move this and DifferenceLogs to installation.
 
-import glob, os.path, subprocess, time
+import glob, os.path, subprocess, time, sys
 
 from Definitions import errorExtension, errorPath, logExtension, logPath, scratchPath, xhtmlExtension
 from optparse    import OptionParser
@@ -118,7 +118,7 @@ def RunExamples ( ):
             eFD   = open ( errorFile, "w" )
             oFD   = open ( logFile  , "w" )
             try:
-                process = subprocess.Popen ( [ "python", inFile ], stderr = eFD, stdout = oFD )
+                process = subprocess.Popen ( [ sys.executable, inFile ], stderr = eFD, stdout = oFD )
                 process.wait ( )
             except Exception as e:
                 eFD.write ( e )

--- a/tutorials/RunTutorials.py
+++ b/tutorials/RunTutorials.py
@@ -1,6 +1,6 @@
 """Run the tutorials."""
 
-import glob, os.path, subprocess, time
+import glob, os.path, subprocess, time, sys
 
 from argparse import ArgumentParser
 from pCore    import CPUTime, YAMLUnpickle
@@ -12,7 +12,7 @@ from pCore    import CPUTime, YAMLUnpickle
 _ErrorExtension  = ".err"
 _LabelWidth      = 50
 _OutputExtension = ".log"
-_PythonCommand   = "python"
+_PythonCommand   = sys.executable
 _ScriptExtension = ".py"
 
 # . Index file name.


### PR DESCRIPTION
Note to @mattbernst : I know you are not maintaining this code. I propose this pull request in the same spirit as you did with this mirror: to make this fix easier to find.


The original code assumes that the Python interpreter used for running
pDynamo scripts is called "python". This is not necessarily true on
systems with multiple Python installations. On many modern
installations, "python" is Python 3, whereas Python 2 has some other
name.

With this patch, examples and tutorials are run in the same Python
interpreter that was specified on the command line when running
RunExamples or RunTutorials.